### PR TITLE
static_any_t fixes

### DIFF
--- a/any.hpp
+++ b/any.hpp
@@ -455,7 +455,9 @@ struct static_any_t
 	static constexpr size_type capacity() { return _N; }
 
 	static_any_t() = default;
+	static_any_t(static_any_t&) = default;
 	static_any_t(const static_any_t&) = default;
+	static_any_t(static_any_t&&) = default;
 
 	template <typename _ValueT>
 	static_any_t(_ValueT&& t)

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -489,8 +489,23 @@ TEST(any, type_identification_across_dll)
 
 TEST(any_t, simple)
 {
-	static_any_t<16> a(7);
+	static_any_t<sizeof(int)> a(7);
 	ASSERT_EQ(7, a.get<int>());
+}
+
+TEST(any_t, copy_from_any_t)
+{
+	static_any_t<sizeof(int)> a(7);
+	static_any_t<sizeof(int)> b(a);
+	ASSERT_EQ(7, b.get<int>());
+}
+
+TEST(any_t, move_from_any_t)
+{
+	static_any_t<sizeof(int)> a(7);
+	static_any_t<sizeof(int)> b(std::move(a));
+	ASSERT_EQ(7, a.get<int>());
+	ASSERT_EQ(7, b.get<int>());
 }
 
 struct unsafe_to_copy


### PR DESCRIPTION
I'm just adding constructors here.  Without these overloads, the compiler erroneously selects the "assign from any" catch-all template constructor, even for operations like moving from another static_any_t of the same size.

It might be nice to parameterize the constructors to match all `static_any_t` which are smaller than ours, but I have not needed that yet, so these fixes just fix the move construction issues.